### PR TITLE
fix(form): change onChange to avoid multiple SelectPizza action dispatch

### DIFF
--- a/src/products/components/pizza-form/pizza-form.component.ts
+++ b/src/products/components/pizza-form/pizza-form.component.ts
@@ -5,15 +5,9 @@ import {
   EventEmitter,
   OnChanges,
   SimpleChanges,
-  ChangeDetectionStrategy,
+  ChangeDetectionStrategy
 } from '@angular/core';
-import {
-  FormControl,
-  FormGroup,
-  FormArray,
-  FormBuilder,
-  Validators,
-} from '@angular/forms';
+import { FormControl, FormGroup, FormArray, FormBuilder, Validators } from '@angular/forms';
 
 import { map } from 'rxjs/operators';
 
@@ -84,7 +78,7 @@ import { Pizza } from '../../models/pizza.model';
 
       </form>
     </div>
-  `,
+  `
 })
 export class PizzaFormComponent implements OnChanges {
   exists = false;
@@ -100,10 +94,15 @@ export class PizzaFormComponent implements OnChanges {
   form = this.fb.group({
     name: ['', Validators.required],
     toppings: [[]],
-    sizes: [[]],
+    sizes: [[]]
   });
 
-  constructor(private fb: FormBuilder) {}
+  constructor(private fb: FormBuilder) {
+    this.form
+      .get('toppings')
+      .valueChanges.pipe(map(toppings => ({ ...this.pizza, toppings })))
+      .subscribe(value => this.selected.emit(value));
+  }
 
   get nameControl() {
     return this.form.get('name') as FormControl;
@@ -114,14 +113,10 @@ export class PizzaFormComponent implements OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.pizza && this.pizza.id) {
+    if (this.pizza && this.pizza.id && !this.exists) {
       this.exists = true;
       this.form.patchValue(this.pizza);
     }
-    this.form
-      .get('toppings')
-      .valueChanges.pipe(map(toppings => ({ ...this.pizza, toppings })))
-      .subscribe(value => this.selected.emit(value));
   }
 
   createPizza(form: FormGroup) {


### PR DESCRIPTION
@toddmotto , hi, my name is `Jia Li`, and I attended your workshop at `ngconf 2018`, it is great, thank you very much. 

And I just finished the `workshop hands one` part. And I found an issue (maybe not).
https://docs.google.com/document/d/1f8CnHwN9tc2cvYq4cnjIPteWA_EafQtE4pdYsrEksI0/edit

After the manual `7h` part, `Select Pizza` and `loading toppings` is done.

And I just `console.log` all the `action` in `pizza.reducer`. I found when I select a `pizza`, the `SelectPizza` action was dispatched `4` times, in my understanding only `1` is correct.

So I did some `debug`, and found because in `pizza-form.component.ts`, `ngOnChanges`, it triggers multiple `selected` eventEmitter.

```javascript
ngOnChanges(changes: SimpleChanges) {
   // I think we should check `this.exists` here, if it is true, we will not patchValue again.
    if (this.pizza && this.pizza.id) {
      this.exists = true;
      this.form.patchValue(this.pizza);
    }

   // and we should only subscribe the valueChanges once in constructor or ngOnInit.
    this.form
      .get('toppings')
      .valueChanges.pipe(map(toppings => ({ ...this.pizza, toppings })))
      .subscribe(value => this.selected.emit(value));
  }
```

So I made this PR to describe my understandings, I am not sure my understanding is correct or not, 
could you check it? 

Thank you so much!